### PR TITLE
fix: octokit request error

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -116,9 +116,9 @@ const postComment = async (
   } catch (error) {
     if (error instanceof RequestError) {
       // NOTE: Retry the API call when the body is too long.
-      const limit = maxCharsFromError(error);
-      if (typeof limit === "number") {
-        await callApi(body.slice(0, limit));
+      const chars = maxCharsFromError(error);
+      if (typeof chars === "number") {
+        await callApi(body.slice(0, chars));
         return;
       }
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -76,7 +76,6 @@ Posted by [ybiquitous/npm-diff-action](https://github.com/ybiquitous/npm-diff-ac
  */
 const maxCharsFromError = (error) => {
   if (error.status === 422) {
-    // unprocessable
     const matched = error.message.match(
       /Body is too long \(maximum is (?<limit>\d+) characters\)/u
     );

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,9 +110,9 @@ const postComment = async (
   } catch (error) {
     if (error instanceof RequestError) {
       // NOTE: Retry the API call when the body is too long.
-      const limit = maxCharsFromError(error);
-      if (typeof limit === "number") {
-        await callApi(body.slice(0, limit));
+      const chars = maxCharsFromError(error);
+      if (typeof chars === "number") {
+        await callApi(body.slice(0, chars));
         return;
       }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -70,7 +70,6 @@ Posted by [ybiquitous/npm-diff-action](https://github.com/ybiquitous/npm-diff-ac
  */
 const maxCharsFromError = (error) => {
   if (error.status === 422) {
-    // unprocessable
     const matched = error.message.match(
       /Body is too long \(maximum is (?<limit>\d+) characters\)/u
     );

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 const core = require("@actions/core");
 const { exec } = require("@actions/exec");
 const github = require("@actions/github");
+const { RequestError } = require("@octokit/request-error");
 
 /** @typedef {{ name: string, from: string, to: string }} UpdateInfo */
 
@@ -65,20 +66,16 @@ Posted by [ybiquitous/npm-diff-action](https://github.com/ybiquitous/npm-diff-ac
 };
 
 /**
- * @param {any} error
+ * @param {RequestError} error
  */
 const maxCharsFromError = (error) => {
-  if (
-    typeof error === "object" &&
-    error !== null &&
-    error.code === "unprocessable" &&
-    typeof error.message === "string"
-  ) {
+  if (error.status === 422) {
+    // unprocessable
     const matched = error.message.match(
       /Body is too long \(maximum is (?<limit>\d+) characters\)/u
     );
-    if (matched != null) {
-      return Number(matched.groups.limit);
+    if (matched != null && matched.groups != null) {
+      return Number(matched.groups["limit"]); // eslint-disable-line dot-notation -- Prevent TS4111
     }
   }
   return null;
@@ -112,11 +109,13 @@ const postComment = async (
     await callApi(body);
     return;
   } catch (error) {
-    // NOTE: Retry the API call when the body is too long.
-    const limit = maxCharsFromError(error);
-    if (typeof limit === "number") {
-      await callApi(body.slice(0, limit));
-      return;
+    if (error instanceof RequestError) {
+      // NOTE: Retry the API call when the body is too long.
+      const limit = maxCharsFromError(error);
+      if (typeof limit === "number") {
+        await callApi(body.slice(0, limit));
+        return;
+      }
     }
     throw error;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@actions/core": "^1.2.6",
         "@actions/exec": "^1.0.4",
-        "@actions/github": "^4.0.0"
+        "@actions/github": "^4.0.0",
+        "@octokit/request-error": "^2.0.5"
       },
       "devDependencies": {
         "@vercel/ncc": "^0.28.2",
@@ -22,6 +23,7 @@
         "ybiq": "^12.2.1"
       },
       "engines": {
+        "node": ">=12.13.0",
         "npm": ">=7.5.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.4",
-    "@actions/github": "^4.0.0"
+    "@actions/github": "^4.0.0",
+    "@octokit/request-error": "^2.0.5"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.28.2",


### PR DESCRIPTION
```
Deprecation: [@octokit/request-error] `error.code` is deprecated, use `error.status`.
    at RequestError.get (/home/runner/work/_actions/ybiquitous/npm-diff-action/main/dist/index.js:4741:17)
    at maxCharsFromError (/home/runner/work/_actions/ybiquitous/npm-diff-action/main/dist/index.js:80:11)
    at postComment (/home/runner/work/_actions/ybiquitous/npm-diff-action/main/dist/index.js:122:19)
    at processTicksAndRejections (internal/process/task_queues.js:93:5) {
```

Follow-up of #12