### PR TITLE
build(deps): relax `engines.node` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "main": "lib/index.js",
   "engines": {
-    "node": "12",
+    "node": ">=12",
     "npm": ">=7.5.0"
   },
   "scripts": {


### PR DESCRIPTION
This change aims to prevent the following error:
https://github.com/ybiquitous/npm-diff-action/runs/2453161034