### PR TITLE
ci: use nvm for release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - run: nvm install && echo "${NVM_BIN}" >> $GITHUB_PATH
+        shell: bash --login {0}
       - run: npm --global install npm@latest
       - run: npm ci
       - run: git config --local user.name '${{ github.actor }}'


### PR DESCRIPTION
This change aims to fix the following error:
https://github.com/ybiquitous/npm-diff-action/runs/2790934998?check_suite_focus=true#step:3:8