### PR TITLE
refactor: use `getExecOutput()` of @actions/exec

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -7540,15 +7540,8 @@ const npmDiffCommand = ({ name, from, to }) => [
  * @param {string[]} cmdArgs
  */
 const runCommand = async (cmd, cmdArgs) => {
-  let out = "";
-  await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_1__.exec)(cmd, cmdArgs, {
-    listeners: {
-      stdout: (data) => {
-        out += data.toString();
-      },
-    },
-  });
-  return out;
+  const { stdout } = await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_1__.getExecOutput)(cmd, cmdArgs);
+  return stdout;
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 import * as core from "@actions/core";
-import { exec } from "@actions/exec";
+import { exec, getExecOutput } from "@actions/exec";
 import { getOctokit } from "@actions/github";
 import { RequestError } from "@octokit/request-error";
 
@@ -36,15 +36,8 @@ export const npmDiffCommand = ({ name, from, to }) => [
  * @param {string[]} cmdArgs
  */
 const runCommand = async (cmd, cmdArgs) => {
-  let out = "";
-  await exec(cmd, cmdArgs, {
-    listeners: {
-      stdout: (data) => {
-        out += data.toString();
-      },
-    },
-  });
-  return out;
+  const { stdout } = await getExecOutput(cmd, cmdArgs);
+  return stdout;
 };
 
 /**


### PR DESCRIPTION
See also:
- #45
- actions/toolkit#814