### PR TITLE
feat: show package size and files change

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,4 +18,5 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm test
+      - run: npm run test:docker
       - run: npm run release:dry-run

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ import { bytesToSize } from "./utils.js";
 
 /** @typedef {{ name: string, from: string, to: string }} UpdateInfo */
 
-/** @typedef {{ from: number, to: number }} PackageSize */
+/** @typedef {{ fileCount: number, size: number }} PackageInfo */
 
 /**
  * @param {string} text
@@ -43,14 +43,16 @@ const runCommand = async (cmd, cmdArgs) => (await getExecOutput(cmd, cmdArgs)).s
 /**
  * @param {string} name
  * @param {string} version
- * @returns {Promise<number>}
+ * @returns {Promise<PackageInfo>}
  */
-export const getPackageSize = async (name, version) => {
-  const size = await runCommand("npm", ["view", `${name}@${version}`, "dist.unpackedSize"]);
-  if (size === "") {
-    throw new Error("No package size");
+export const getPackageInfo = async (name, version) => {
+  const pkg = `${name}@${version}`;
+  const ret = await runCommand("npm", ["view", "--json", pkg, "dist"]);
+  if (ret === "") {
+    throw new Error(`No package info of ${pkg}`);
   }
-  return Number(size);
+  const info = JSON.parse(ret);
+  return { fileCount: Number(info.fileCount), size: Number(info.unpackedSize) };
 };
 
 /**
@@ -58,11 +60,11 @@ export const getPackageSize = async (name, version) => {
  *   cmd: string,
  *   cmdArgs: string[],
  *   diff: string,
- *   packageSize: PackageSize,
+ *   packageInfo: { from: PackageInfo, to: PackageInfo },
  *   truncated?: boolean,
  * }} args
  */
-export const buildCommentBody = ({ cmd, cmdArgs, diff, packageSize, truncated = false }) => {
+export const buildCommentBody = ({ cmd, cmdArgs, diff, packageInfo, truncated = false }) => {
   const cmdLine = [cmd, ...cmdArgs].join(" ");
   return `
 <details>
@@ -74,7 +76,8 @@ ${diff.trim()}
 ${truncated ? "\n_(too long so truncated)_\n" : ""}
 </details>
 
-Size: ${bytesToSize(packageSize.from)} → **${bytesToSize(packageSize.to)}**
+- Size: ${bytesToSize(packageInfo.from.size)} → **${bytesToSize(packageInfo.to.size)}**
+- Files: ${packageInfo.from.fileCount} → **${packageInfo.to.fileCount}**
 
 Posted by [ybiquitous/npm-diff-action](https://github.com/ybiquitous/npm-diff-action)
 `;
@@ -100,7 +103,7 @@ const maxCharsFromError = (error) => {
  *   cmd: string,
  *   cmdArgs: string[],
  *   diff: string,
- *   packageSize: PackageSize,
+ *   packageInfo: { from: PackageInfo, to: PackageInfo },
  *   client?: ReturnType<getOctokit>,
  *   repository?: string,
  *   pullNumber?: string,
@@ -111,7 +114,7 @@ export const postComment = async ({
   cmd,
   cmdArgs,
   diff,
-  packageSize,
+  packageInfo,
   client = getOctokit(core.getInput("token")),
   repository = core.getInput("repository"),
   pullNumber = core.getInput("pull_request_number"),
@@ -130,7 +133,7 @@ export const postComment = async ({
     });
 
   try {
-    await callApi(buildCommentBody({ cmd, cmdArgs, diff, packageSize }));
+    await callApi(buildCommentBody({ cmd, cmdArgs, diff, packageInfo }));
     return;
   } catch (error) {
     if (error instanceof RequestError) {
@@ -142,7 +145,7 @@ export const postComment = async ({
           cmd,
           cmdArgs,
           diff: diff.slice(0, maxChars - bufferChars),
-          packageSize,
+          packageInfo,
           truncated: true,
         });
         await callApi(body);
@@ -177,15 +180,15 @@ const run = async () => {
 
   const diff = await core.group("Run npm diff", () => runCommand(cmd, cmdArgs));
 
-  const oldPackageSize = await core.group("Get old package size", () =>
-    getPackageSize(updateInfo.name, updateInfo.from)
+  const oldPackageInfo = await core.group("Get old package info", () =>
+    getPackageInfo(updateInfo.name, updateInfo.from)
   );
-  const newPackageSize = await core.group("Get new package size", () =>
-    getPackageSize(updateInfo.name, updateInfo.to)
+  const newPackageInfo = await core.group("Get new package info", () =>
+    getPackageInfo(updateInfo.name, updateInfo.to)
   );
 
   await core.group("Post comment", () =>
-    postComment({ cmd, cmdArgs, diff, packageSize: { from: oldPackageSize, to: newPackageSize } })
+    postComment({ cmd, cmdArgs, diff, packageInfo: { from: oldPackageInfo, to: newPackageInfo } })
   );
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,8 +2,11 @@ import * as core from "@actions/core";
 import { exec, getExecOutput } from "@actions/exec";
 import { getOctokit } from "@actions/github";
 import { RequestError } from "@octokit/request-error";
+import { bytesToSize } from "./utils.js";
 
 /** @typedef {{ name: string, from: string, to: string }} UpdateInfo */
+
+/** @typedef {{ from: number, to: number }} PackageSize */
 
 /**
  * @param {string} text
@@ -35,19 +38,31 @@ export const npmDiffCommand = ({ name, from, to }) => [
  * @param {string} cmd
  * @param {string[]} cmdArgs
  */
-const runCommand = async (cmd, cmdArgs) => {
-  const { stdout } = await getExecOutput(cmd, cmdArgs);
-  return stdout;
+const runCommand = async (cmd, cmdArgs) => (await getExecOutput(cmd, cmdArgs)).stdout;
+
+/**
+ * @param {string} name
+ * @param {string} version
+ * @returns {Promise<number>}
+ */
+export const getPackageSize = async (name, version) => {
+  const size = await runCommand("npm", ["view", `${name}@${version}`, "dist.unpackedSize"]);
+  if (size === "") {
+    throw new Error("No package size");
+  }
+  return Number(size);
 };
 
 /**
- * @param {string} cmd
- * @param {string[]} cmdArgs
- * @param {string} diff
- * @param {boolean} truncated
+ * @param {{
+ *   cmd: string,
+ *   cmdArgs: string[],
+ *   diff: string,
+ *   packageSize: PackageSize,
+ *   truncated?: boolean,
+ * }} args
  */
-// eslint-disable-next-line max-params
-export const buildCommentBody = (cmd, cmdArgs, diff, truncated = false) => {
+export const buildCommentBody = ({ cmd, cmdArgs, diff, packageSize, truncated = false }) => {
   const cmdLine = [cmd, ...cmdArgs].join(" ");
   return `
 <details>
@@ -58,6 +73,8 @@ ${diff.trim()}
 \`\`\`\`
 ${truncated ? "\n_(too long so truncated)_\n" : ""}
 </details>
+
+Size: ${bytesToSize(packageSize.from)} → **${bytesToSize(packageSize.to)}**
 
 Posted by [ybiquitous/npm-diff-action](https://github.com/ybiquitous/npm-diff-action)
 `;
@@ -79,23 +96,26 @@ const maxCharsFromError = (error) => {
 };
 
 /**
- * @param {string} cmd
- * @param {string[]} cmdArgs
- * @param {string} diff
- * @param {{ client: ReturnType<getOctokit>, repository: string, number: string }} options
+ * @param {{
+ *   cmd: string,
+ *   cmdArgs: string[],
+ *   diff: string,
+ *   packageSize: PackageSize,
+ *   client?: ReturnType<getOctokit>,
+ *   repository?: string,
+ *   pullNumber?: string,
+ * }} args
  */
 // eslint-disable-next-line max-statements
-export const postComment = async (
+export const postComment = async ({
   cmd,
   cmdArgs,
   diff,
-  { client, repository, number } = {
-    client: getOctokit(core.getInput("token")),
-    repository: core.getInput("repository"),
-    number: core.getInput("pull_request_number"),
-  }
-  // eslint-disable-next-line max-params
-) => {
+  packageSize,
+  client = getOctokit(core.getInput("token")),
+  repository = core.getInput("repository"),
+  pullNumber = core.getInput("pull_request_number"),
+}) => {
   const [owner, repo] = repository.split("/");
   if (owner == null || repo == null) {
     throw new Error(`"${repository}" is an invalid repository`);
@@ -105,12 +125,12 @@ export const postComment = async (
     client.rest.issues.createComment({
       owner,
       repo,
-      issue_number: Number(number),
+      issue_number: Number(pullNumber),
       body: commentBody,
     });
 
   try {
-    await callApi(buildCommentBody(cmd, cmdArgs, diff));
+    await callApi(buildCommentBody({ cmd, cmdArgs, diff, packageSize }));
     return;
   } catch (error) {
     if (error instanceof RequestError) {
@@ -118,7 +138,13 @@ export const postComment = async (
       if (typeof maxChars === "number") {
         core.info("Retring the API call because the request body is too long...");
         const bufferChars = 500;
-        const body = buildCommentBody(cmd, cmdArgs, diff.slice(0, maxChars - bufferChars), true);
+        const body = buildCommentBody({
+          cmd,
+          cmdArgs,
+          diff: diff.slice(0, maxChars - bufferChars),
+          packageSize,
+          truncated: true,
+        });
         await callApi(body);
         return;
       }
@@ -148,8 +174,19 @@ const run = async () => {
   if (updateInfo == null) return;
 
   const [cmd, cmdArgs] = npmDiffCommand(updateInfo);
+
   const diff = await core.group("Run npm diff", () => runCommand(cmd, cmdArgs));
-  await core.group("Post comment", () => postComment(cmd, cmdArgs, diff));
+
+  const oldPackageSize = await core.group("Get old package size", () =>
+    getPackageSize(updateInfo.name, updateInfo.from)
+  );
+  const newPackageSize = await core.group("Get new package size", () =>
+    getPackageSize(updateInfo.name, updateInfo.to)
+  );
+
+  await core.group("Post comment", () =>
+    postComment({ cmd, cmdArgs, diff, packageSize: { from: oldPackageSize, to: newPackageSize } })
+  );
 };
 
 if (process.env["NODE_ENV"] !== "test") {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,14 @@
+/**
+ * @see https://gist.github.com/lanqy/5193417
+ *
+ * @param {number} bytes
+ * @returns {string}
+ */
+export function bytesToSize(bytes) {
+  const sizes = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(Math.abs(bytes)) / Math.log(1024));
+  if (i === 0 || Number.isNaN(i)) {
+    return `${bytes} ${sizes[i] ?? sizes[0]}`;
+  }
+  return `${(bytes / 1024 ** i).toFixed(1)} ${sizes[i]}`;
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "prepare": "husky install",
     "build": "ncc build lib/index.js --out dist",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest && npm run test:docker",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:watch": "npm run test -- --watch",
     "test:coverage": "npm run test -- --coverage",
     "test:docker": "DOCKER_BUILDKIT=1 docker build -t npm-diff-action:dev . && docker run --rm npm-diff-action:dev",

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -11,7 +11,8 @@ diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-
 
 </details>
 
-Size: 50 B → **100 B**
+- Size: 1.1 KB → **956 B**
+- Files: 23 → **17**
 
 Posted by [ybiquitous/npm-diff-action](https://github.com/ybiquitous/npm-diff-action)
 "
@@ -30,7 +31,8 @@ _(too long so truncated)_
 
 </details>
 
-Size: 50 B → **100 B**
+- Size: 1.1 KB → **956 B**
+- Files: 23 → **17**
 
 Posted by [ybiquitous/npm-diff-action](https://github.com/ybiquitous/npm-diff-action)
 "

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -11,6 +11,8 @@ diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-
 
 </details>
 
+Size: 50 B → **100 B**
+
 Posted by [ybiquitous/npm-diff-action](https://github.com/ybiquitous/npm-diff-action)
 "
 `;
@@ -27,6 +29,8 @@ diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-diff-
 _(too long so truncated)_
 
 </details>
+
+Size: 50 B → **100 B**
 
 Posted by [ybiquitous/npm-diff-action](https://github.com/ybiquitous/npm-diff-action)
 "


### PR DESCRIPTION
This change aims to show a package size and files change on a posted comment.
We can get such a package size via the `npm view` command.
(see <https://docs.npmjs.com/cli/v7/commands/npm-view>)