### PR TITLE
feat: remove `npm run build` and `@vercel/ncc`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,7 @@
-FROM node:16-alpine as build
+FROM node:16-alpine
 
 COPY package*.json /
 COPY lib/* /lib/
-RUN npm ci --ignore-scripts && \
-    npm run build
+RUN npm ci --ignore-scripts --production
 
-FROM node:16-alpine
-
-COPY --from=build dist/* /
-
-ENTRYPOINT ["node", "/index.js"]
+ENTRYPOINT ["node", "."]

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@octokit/request-error": "^2.1.0"
       },
       "devDependencies": {
-        "@vercel/ncc": "^0.29.0",
         "eslint": "^7.32.0",
         "eslint-config-ybiquitous": "^14.0.1",
         "eslint-plugin-jest": "^24.4.0",
@@ -23,7 +22,7 @@
         "ybiq": "^13.4.0"
       },
       "engines": {
-        "node": ">=12",
+        "node": ">=16",
         "npm": ">=7.5.0"
       }
     },
@@ -1754,15 +1753,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@vercel/ncc": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.29.0.tgz",
-      "integrity": "sha512-p+sB835wOSDdgm2mgFgSOcXJF84AqZ+vBEnnGS0sm8veA92Hia7sqH0qEnqeFilPl+cXtxbdh2er+WdlfbVCZA==",
-      "dev": true,
-      "bin": {
-        "ncc": "dist/ncc/cli.js"
       }
     },
     "node_modules/abab": {
@@ -12658,12 +12648,6 @@
         "@typescript-eslint/types": "4.21.0",
         "eslint-visitor-keys": "^2.0.0"
       }
-    },
-    "@vercel/ncc": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.29.0.tgz",
-      "integrity": "sha512-p+sB835wOSDdgm2mgFgSOcXJF84AqZ+vBEnnGS0sm8veA92Hia7sqH0qEnqeFilPl+cXtxbdh2er+WdlfbVCZA==",
-      "dev": true
     },
     "abab": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "scripts": {
     "prepare": "husky install",
-    "build": "ncc build lib/index.js --out dist",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:watch": "npm run test -- --watch",
     "test:coverage": "npm run test -- --coverage",
@@ -49,7 +48,6 @@
     "@octokit/request-error": "^2.1.0"
   },
   "devDependencies": {
-    "@vercel/ncc": "^0.29.0",
     "eslint": "^7.32.0",
     "eslint-config-ybiquitous": "^14.0.1",
     "eslint-plugin-jest": "^24.4.0",


### PR DESCRIPTION
Since PR #67 (with a Docker container), this project no longer needs the `build` phase.