### PR TITLE
chore: remove `main` field from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "npm-diff-action",
       "version": "1.1.2",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "dependency"
   ],
   "type": "module",
-  "main": "lib/index.js",
   "engines": {
     "node": ">=16",
     "npm": ">=7.5.0"


### PR DESCRIPTION
The entrypoint for CommonJS is unnecessary. See below:
https://nodejs.org/api/packages.html#packages_main