### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11288,9 +11288,9 @@
       }
     },
     "node_modules/trim-off-newlines": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.3.tgz",
+      "integrity": "sha512-kh6Tu6GbeSNMGfrrZh6Bb/4ZEHV1QlB4xNDBeog8Y9/QwFlKTRyWvY3Fs9tRDAMZliVUwieMgEdIeL/FtqjkJg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11875,9 +11875,9 @@
       }
     },
     "node_modules/vfile-reporter/node_modules/ansi-regex": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.0.tgz",
-      "integrity": "sha512-tAaOSrWCHF+1Ear1Z4wnJCXA9GGox4K6Ic85a5qalES2aeEwQGr7UC93mwef49536PkCYjzkp0zIxfFvexJ6zQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -20815,9 +20815,9 @@
       "dev": true
     },
     "trim-off-newlines": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.3.tgz",
+      "integrity": "sha512-kh6Tu6GbeSNMGfrrZh6Bb/4ZEHV1QlB4xNDBeog8Y9/QwFlKTRyWvY3Fs9tRDAMZliVUwieMgEdIeL/FtqjkJg==",
       "dev": true
     },
     "trough": {
@@ -21261,9 +21261,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.0.tgz",
-          "integrity": "sha512-tAaOSrWCHF+1Ear1Z4wnJCXA9GGox4K6Ic85a5qalES2aeEwQGr7UC93mwef49536PkCYjzkp0zIxfFvexJ6zQ==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
           "dev": true
         },
         "has-flag": {


### PR DESCRIPTION
This pull request fixes the vulnerable packages via npm [8.1.0](https://github.com/npm/cli/releases/tag/v8.1.0).

<details open>
<summary><strong>Updated (2)</strong></summary>

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [ansi-regex](https://www.npmjs.com/package/ansi-regex/v/6.0.1) (`vfile-reporter/node_modules/ansi-regex`) | `6.0.0` → `6.0.1` | [github](https://github.com/chalk/ansi-regex) | **[Moderate]**  Inefficient Regular Expression Complexity in chalk/ansi-regex ([ref](https://github.com/advisories/GHSA-93q8-gq69-wqmw)) |
| [trim-off-newlines](https://www.npmjs.com/package/trim-off-newlines/v/1.0.3) | `1.0.1` → `1.0.3` | [github](https://github.com/stevemao/trim-off-newlines) | **[Moderate]** Uncontrolled Resource Consumption in trim-off-newlines ([ref](https://github.com/advisories/GHSA-38fc-wpqx-33j7)) |

</details>

***

Created by [ybiquitous/npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action)