### PR TITLE
ci: remove needless `npm run lint`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
           node-version: "16"
           cache: npm
       - run: npm ci
-      - run: npm run lint
       - run: npm test
       - run: npm run test:docker
       - run: npm run release:dry-run


### PR DESCRIPTION
With #110, `npm run lint` was integrated into `npm test`.