### PR TITLE
fix: incorrect package version on posted comment

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import * as core from "@actions/core";
 import { exec, getExecOutput } from "@actions/exec";
 import { getOctokit } from "@actions/github";
@@ -181,9 +182,19 @@ export const postComment = async ({
  * @returns {Promise<Versions>}
  */
 const showVersions = async () => {
-  const json = await runCommand("npm", ["version", "--json"]);
-  const vers = JSON.parse(json);
-  return { node: vers.node, npm: vers.npm, self: vers["npm-diff-action"] };
+  const versionJson = await runCommand("npm", ["version", "--json"]);
+  const version = JSON.parse(versionJson);
+  if (!(version && version.node && version.npm)) {
+    throw new Error(`Invalid versions: '${versionJson}'`);
+  }
+
+  const packageJson = await readFile(new URL("../package.json", import.meta.url).pathname);
+  const pkg = JSON.parse(packageJson.toString());
+  if (!(pkg && pkg.version)) {
+    throw new Error(`Invalid package.json: '${packageJson}'`);
+  }
+
+  return { node: version.node, npm: version.npm, self: pkg.version };
 };
 
 const run = async () => {


### PR DESCRIPTION
Using the `npm version` command is incorrect to get this package version.
Instead, it's necessary to read the `package.json` file.