### PR TITLE
fix: `npm view` failure error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import { URL } from "node:url";
 import * as core from "@actions/core";
 import { exec, getExecOutput } from "@actions/exec";
 import { getOctokit } from "@actions/github";
@@ -50,9 +51,12 @@ const runCommand = async (cmd, cmdArgs) => (await getExecOutput(cmd, cmdArgs)).s
  */
 export const getPackageInfo = async (name, version) => {
   const pkg = `${name}@${version}`;
-  const ret = await runCommand("npm", ["view", "--json", pkg, "dist"]);
-  if (ret === "") {
-    throw new Error(`No package info of ${pkg}`);
+  let ret;
+  try {
+    ret = await runCommand("npm", ["view", "--json", pkg, "dist"]);
+  } catch (error) {
+    // TODO: Use `{ cause: error }` option. See https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/Error#browser_compatibility
+    throw new Error(`Failed to get package info of "${pkg}" due to: ${error}`);
   }
   const info = JSON.parse(ret);
   return { fileCount: Number(info.fileCount), size: Number(info.unpackedSize) };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@octokit/request-error": "^2.1.0"
       },
       "devDependencies": {
+        "@tsconfig/node16-strictest-esm": "^1.0.3",
         "eslint": "^8.14.0",
         "eslint-config-ybiquitous": "^15.2.0",
         "eslint-plugin-jest": "^26.1.5",
@@ -24,7 +25,7 @@
       },
       "engines": {
         "node": "^16.15.0 || >=18",
-        "npm": ">=8.6.0"
+        "npm": ">=8.13.2"
       }
     },
     "node_modules/@actions/core": {
@@ -1825,6 +1826,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16-strictest-esm": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16-strictest-esm/-/node16-strictest-esm-1.0.3.tgz",
+      "integrity": "sha512-0/QTPDkKmE2dy0dMRstPCv4VJ+gUGgvMKzaWd5P3hgdlmPqYqe1pJxDGUlNYbSgUBlncIvvX+mIeZarokysNgg==",
       "dev": true
     },
     "node_modules/@types/babel__core": {
@@ -13278,6 +13285,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
+    "@tsconfig/node16-strictest-esm": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16-strictest-esm/-/node16-strictest-esm-1.0.3.tgz",
+      "integrity": "sha512-0/QTPDkKmE2dy0dMRstPCv4VJ+gUGgvMKzaWd5P3hgdlmPqYqe1pJxDGUlNYbSgUBlncIvvX+mIeZarokysNgg==",
       "dev": true
     },
     "@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "type": "module",
   "engines": {
     "node": "^16.15.0 || >=18",
-    "npm": ">=8.6.0"
+    "npm": ">=8.13.2"
   },
   "scripts": {
     "prepare": "husky install",
@@ -48,6 +48,7 @@
     "@octokit/request-error": "^2.1.0"
   },
   "devDependencies": {
+    "@tsconfig/node16-strictest-esm": "^1.0.3",
     "eslint": "^8.14.0",
     "eslint-config-ybiquitous": "^15.2.0",
     "eslint-plugin-jest": "^26.1.5",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -299,7 +299,7 @@ describe("getPackageInfo()", () => {
 
   test("failure", async () => {
     await expect(getPackageInfo("npm", "7.20.100")).rejects.toThrow(
-      new Error("No package info of npm@7.20.100")
+      /Failed to get package info of "npm@7\.20\.100" due to:/u
     );
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,5 @@
 {
-  "compilerOptions": {
-    "checkJs": true,
-    "strict": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitReturns": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "module": "ES2020",
-    "moduleResolution": "node"
-  },
+  "extends": "@tsconfig/node16-strictest-esm/tsconfig.json",
+  "compilerOptions": {},
   "include": ["lib"]
 }


### PR DESCRIPTION
The `npm view` command behavior may change.

See <https://github.com/ybiquitous/npm-diff-action/runs/7143649734?check_suite_focus=true#step:6:80>

Also, this change adds the `@tsconfig/node16-strictest-esm` package for better type-check.