### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,11 +29,20 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.7.0.tgz",
-      "integrity": "sha512-7fPSS7yKOhTpgLMbw7lBLc1QJWvJBBAgyTX2PEhagWcKK8t0H8AKCoPMfnrHqIm5cRYH4QFPqD1/ruhuUE7YcQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
       "dependencies": {
-        "@actions/http-client": "^1.0.11"
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@actions/core/node_modules/@actions/http-client": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+      "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+      "dependencies": {
+        "tunnel": "^0.0.6"
       }
     },
     "node_modules/@actions/exec": {
@@ -11494,6 +11503,14 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/uvu": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.3.tgz",
@@ -11932,11 +11949,22 @@
   },
   "dependencies": {
     "@actions/core": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.7.0.tgz",
-      "integrity": "sha512-7fPSS7yKOhTpgLMbw7lBLc1QJWvJBBAgyTX2PEhagWcKK8t0H8AKCoPMfnrHqIm5cRYH4QFPqD1/ruhuUE7YcQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
       "requires": {
-        "@actions/http-client": "^1.0.11"
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@actions/http-client": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+          "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+          "requires": {
+            "tunnel": "^0.0.6"
+          }
+        }
       }
     },
     "@actions/exec": {
@@ -20449,6 +20477,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "uvu": {
       "version": "0.5.3",


### PR DESCRIPTION
This pull request fixes the vulnerable packages via npm [8.18.0](https://github.com/npm/cli/releases/tag/v8.18.0).

<details open>
<summary><strong>Updated (1)</strong></summary>

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [@actions/core](https://www.npmjs.com/package/@actions/core/v/1.9.1) | `1.7.0` → `1.9.1` | [github](https://github.com/actions/toolkit) | **[Moderate]** @actions/core has Delimiter Injection Vulnerability in exportVariable ([ref](https://github.com/advisories/GHSA-7r3h-m5j6-3q42)) |

</details>

<details open>
<summary><strong>Added (2)</strong></summary>

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [@actions/http-client](https://www.npmjs.com/package/@actions/http-client/v/2.0.1) (`@actions/core/node_modules/@actions/http-client`) | `2.0.1` | [github](https://github.com/actions/toolkit) | - |
| [uuid](https://www.npmjs.com/package/uuid/v/8.3.2) | `8.3.2` | [github](https://github.com/uuidjs/uuid) | - |

</details>

***

Created by [ybiquitous/npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action)