### PR TITLE
ci: enable npm's `engine-strict` only on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["**"]
 
+env:
+  npm_config_engine_strict: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict = true


### PR DESCRIPTION
To prevent Dependabot errors.

See also <https://docs.npmjs.com/cli/v8/using-npm/config#environment-variables>