### PR TITLE
fix: replace `--production` with `--omit=dev` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM node:18-alpine
 
 COPY package*.json /
 COPY lib/* /lib/
-RUN npm ci --ignore-scripts --production
+RUN npm ci --ignore-scripts --omit=dev
 
 ENTRYPOINT ["node", "/lib/index.js"]


### PR DESCRIPTION
To prevent the warning below:

```
npm WARN config production Use `--omit=dev` instead.
```