### PR TITLE
ci: set permissions for `npm-diff` workflow

### DIFF
--- a/.github/workflows/npm-diff.yml
+++ b/.github/workflows/npm-diff.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   post-comment:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: ./


### PR DESCRIPTION
See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token