### PR TITLE
fix: use `Error.cause` option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,8 +55,8 @@ export const getPackageInfo = async (name, version) => {
   try {
     ret = await runCommand("npm", ["view", "--json", pkg, "dist"]);
   } catch (error) {
-    // TODO: Use `{ cause: error }` option. See https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/Error#browser_compatibility
-    throw new Error(`Failed to get package info of "${pkg}" due to: ${error}`);
+    const options = error instanceof Error ? { cause: error } : undefined;
+    throw new Error(`Failed to get package info of "${pkg}" due to: ${error}`, options);
   }
   const info = JSON.parse(ret);
   return { fileCount: Number(info.fileCount), size: Number(info.unpackedSize) };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@octokit/request-error": "^3.0.2"
       },
       "devDependencies": {
-        "@tsconfig/node16-strictest-esm": "^1.0.3",
+        "@tsconfig/node18-strictest-esm": "^1.0.1",
         "eslint": "^8.28.0",
         "eslint-config-ybiquitous": "^16.2.0",
         "eslint-plugin-jest": "^27.1.6",
@@ -2128,10 +2128,10 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
-    "node_modules/@tsconfig/node16-strictest-esm": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16-strictest-esm/-/node16-strictest-esm-1.0.3.tgz",
-      "integrity": "sha512-0/QTPDkKmE2dy0dMRstPCv4VJ+gUGgvMKzaWd5P3hgdlmPqYqe1pJxDGUlNYbSgUBlncIvvX+mIeZarokysNgg==",
+    "node_modules/@tsconfig/node18-strictest-esm": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18-strictest-esm/-/node18-strictest-esm-1.0.1.tgz",
+      "integrity": "sha512-cHzmAqw7CMbyqROWeBgVhard3F2V6zxOSJnQ4E6SJWruXD5ypuP9/QKekwBdfXQ4oUTaizIICKIwb+v3v33t0w==",
       "dev": true
     },
     "node_modules/@types/babel__core": {
@@ -14215,10 +14215,10 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
-    "@tsconfig/node16-strictest-esm": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16-strictest-esm/-/node16-strictest-esm-1.0.3.tgz",
-      "integrity": "sha512-0/QTPDkKmE2dy0dMRstPCv4VJ+gUGgvMKzaWd5P3hgdlmPqYqe1pJxDGUlNYbSgUBlncIvvX+mIeZarokysNgg==",
+    "@tsconfig/node18-strictest-esm": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18-strictest-esm/-/node18-strictest-esm-1.0.1.tgz",
+      "integrity": "sha512-cHzmAqw7CMbyqROWeBgVhard3F2V6zxOSJnQ4E6SJWruXD5ypuP9/QKekwBdfXQ4oUTaizIICKIwb+v3v33t0w==",
       "dev": true
     },
     "@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@octokit/request-error": "^3.0.2"
   },
   "devDependencies": {
-    "@tsconfig/node16-strictest-esm": "^1.0.3",
+    "@tsconfig/node18-strictest-esm": "^1.0.1",
     "eslint": "^8.28.0",
     "eslint-config-ybiquitous": "^16.2.0",
     "eslint-plugin-jest": "^27.1.6",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node16-strictest-esm/tsconfig.json",
+  "extends": "@tsconfig/node18-strictest-esm/tsconfig.json",
   "compilerOptions": {},
   "include": ["lib"]
 }


### PR DESCRIPTION
To pass TypeScript compile errors, this updates `@tsconfig/node16-strictest-esm` to `@tsconfig/node18-strictest-esm`.

