### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18522,9 +18522,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.0.tgz",
-      "integrity": "sha512-l3ydWhlhOJzMVOYkymLykcRRXqbUaQriERtR70B9LzNkZ4bX52Fc8wbTDneMiwo8T+AemZXvXaTx+9o5ROxrXg==",
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -32467,9 +32467,9 @@
       }
     },
     "undici": {
-      "version": "5.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.0.tgz",
-      "integrity": "sha512-l3ydWhlhOJzMVOYkymLykcRRXqbUaQriERtR70B9LzNkZ4bX52Fc8wbTDneMiwo8T+AemZXvXaTx+9o5ROxrXg==",
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
       "requires": {
         "@fastify/busboy": "^2.0.0"
       }


### PR DESCRIPTION
This pull request fixes the vulnerable packages via npm [10.5.0](https://github.com/npm/cli/releases/tag/v10.5.0).

<details open>
<summary><strong>Updated (1)</strong></summary>

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [undici](https://www.npmjs.com/package/undici/v/5.28.4) | `5.27.0` → `5.28.4` | [github](https://github.com/nodejs/undici) | **[Low]** Undici proxy-authorization header not cleared on cross-origin redirect in fetch ([ref](https://github.com/advisories/GHSA-3787-6prv-h9w3)) |

</details>

***

Created by [ybiquitous/npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action)