### PR TITLE
chore(deps): ignore ESlint major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     groups:
       eslint:
         patterns: ["eslint", "eslint-*"]
+    ignore:
+      # TODO: This will be unnecessary when updating ESLint to v9.
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Updating ESLint to v9 will still take time.