### PR TITLE
Revert "fix: skip npm diff for private packages"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -209,14 +209,6 @@ const showVersions = async () => {
   return { node: version.node, npm: version.npm, self: pkg.version };
 };
 
-/**
- * @returns {Promise<boolean>}
- */
-const checkPrivatePackage = async () => {
-  const output = await runCommand("npm", ["pkg", "get", "private"]);
-  return output.trim() === "true";
-};
-
 const run = async () => {
   await core.group("Install the latest npm", () =>
     exec("npm", ["install", "--global", "npm@latest"]),
@@ -236,14 +228,6 @@ const run = async () => {
     return Promise.resolve(info);
   });
   if (updateInfo == null) return;
-
-  const isPrivatePackage = await core.group("Check whether the package is private", () =>
-    checkPrivatePackage(),
-  );
-  if (isPrivatePackage) {
-    core.info("The package is private. Skip npm diff.");
-    return;
-  }
 
   const [cmd, cmdArgs] = npmDiffCommand(updateInfo);
 


### PR DESCRIPTION
Reverts ybiquitous/npm-diff-action#445

Checking private packages without extracted package info makes no sense.